### PR TITLE
remove all vpc private endpoints

### DIFF
--- a/galv_cdk/backend_stack.py
+++ b/galv_cdk/backend_stack.py
@@ -206,48 +206,6 @@ class GalvBackend(Stack):
         for subnet in self.vpc.private_subnets:
             Tags.of(subnet).add("AZ", subnet.availability_zone)
 
-        # Add interface endpoints for private access to AWS services
-        self.vpc_endpoint_sg = aws_ec2.SecurityGroup(self, f"{self.name}-EndpointSG", vpc=self.vpc)
-        self.vpc_endpoint_sg.add_ingress_rule(aws_ec2.Peer.ipv4(self.vpc.vpc_cidr_block), aws_ec2.Port.tcp(443), "HTTPS from VPC")
-
-        self.vpc.add_interface_endpoint(
-            "SecretsManagerEndpoint",
-            service=aws_ec2.InterfaceVpcEndpointAwsService.SECRETS_MANAGER,
-            security_groups=[self.vpc_endpoint_sg],
-            subnets=aws_ec2.SubnetSelection(subnet_type=aws_ec2.SubnetType.PRIVATE_WITH_EGRESS)
-        )
-
-        self.vpc.add_interface_endpoint(
-            "CloudWatchLogsEndpoint",
-            service=aws_ec2.InterfaceVpcEndpointAwsService.CLOUDWATCH_LOGS,
-            security_groups=[self.vpc_endpoint_sg],
-            private_dns_enabled=True,
-            subnets=aws_ec2.SubnetSelection(subnet_type=aws_ec2.SubnetType.PRIVATE_WITH_EGRESS)
-        )
-
-        self.vpc.add_interface_endpoint(
-            "EcrApiEndpoint",
-            service=aws_ec2.InterfaceVpcEndpointAwsService.ECR,
-            subnets=aws_ec2.SubnetSelection(subnet_type=aws_ec2.SubnetType.PRIVATE_WITH_EGRESS),
-            security_groups=[self.vpc_endpoint_sg],
-        )
-
-        self.vpc.add_interface_endpoint(
-            "EcrDockerEndpoint",
-            service=aws_ec2.InterfaceVpcEndpointAwsService.ECR_DOCKER,
-            subnets=aws_ec2.SubnetSelection(subnet_type=aws_ec2.SubnetType.PRIVATE_WITH_EGRESS),
-            security_groups=[self.vpc_endpoint_sg],
-        )
-
-        # Allow services to access STS for IAM role assumption
-        self.vpc.add_interface_endpoint(
-            "StsEndpoint",
-            service=aws_ec2.InterfaceVpcEndpointAwsService.STS,
-            private_dns_enabled=True,
-            subnets=aws_ec2.SubnetSelection(subnet_type=aws_ec2.SubnetType.PRIVATE_WITH_EGRESS),
-            security_groups=[self.vpc_endpoint_sg]
-        )
-
         self.vpc.add_gateway_endpoint(
             "S3Endpoint",
             service=aws_ec2.GatewayVpcEndpointAwsService.S3,
@@ -273,22 +231,6 @@ class GalvBackend(Stack):
         self.db_sg.add_ingress_rule(self.backend_sg, aws_ec2.Port.tcp(5432), "Postgres from backend service")
         self.db_sg.add_ingress_rule(self.setup_sg, aws_ec2.Port.tcp(5432), "Postgres from setup task")
         self.db_sg.add_ingress_rule(self.monitor_sg, aws_ec2.Port.tcp(5432), "Postgres from monitor task")
-
-        self.vpc_endpoint_sg.add_ingress_rule(
-            aws_ec2.Peer.security_group_id(self.backend_sg.security_group_id),
-            aws_ec2.Port.tcp(443),
-            "Allow HTTPS from backend service to ECR endpoints"
-        )
-        self.vpc_endpoint_sg.add_ingress_rule(
-            aws_ec2.Peer.security_group_id(self.monitor_sg.security_group_id),
-            aws_ec2.Port.tcp(443),
-            "Allow HTTPS from monitor task to ECR endpoints"
-        )
-        self.vpc_endpoint_sg.add_ingress_rule(
-            aws_ec2.Peer.security_group_id(self.setup_sg.security_group_id),
-            aws_ec2.Port.tcp(443),
-            "Allow HTTPS from setup task to VPC endpoints"
-        )
 
     def _create_storage(self):
         """

--- a/galv_cdk/frontend_stack.py
+++ b/galv_cdk/frontend_stack.py
@@ -181,20 +181,6 @@ class GalvFrontend(Stack):
             description="Allow HTTP traffic from ALB",
         )
 
-        vpc.add_interface_endpoint(
-            "EcrApiEndpoint",
-            service=ec2.InterfaceVpcEndpointAwsService.ECR,
-            subnets=ec2.SubnetSelection(subnet_type=ec2.SubnetType.PRIVATE_WITH_EGRESS),
-            security_groups=[ecs_sg],
-        )
-
-        vpc.add_interface_endpoint(
-            "EcrDockerEndpoint",
-            service=ec2.InterfaceVpcEndpointAwsService.ECR_DOCKER,
-            subnets=ec2.SubnetSelection(subnet_type=ec2.SubnetType.PRIVATE_WITH_EGRESS),
-            security_groups=[ecs_sg],
-        )
-
         enable_insights = self.node.try_get_context("enableContainerInsights")
         if enable_insights is None:
             enable_insights = self.is_production

--- a/galv_cdk/nag_suppressions.py
+++ b/galv_cdk/nag_suppressions.py
@@ -98,38 +98,55 @@ def _suppress_taskrole_policy(stack: Stack, name: str):
 
 
 def _suppress_vpc_endpoints(stack: Stack, name: str):
-    if stack.__class__.__name__ != "GalvBackend":
-        NagSuppressions.add_resource_suppressions(
-            stack,
-            [
-                {"id": "HIPAA.Security-VPCDefaultSecurityGroupClosed",
-                 "reason": "Default SG is unused; all resources have explicit SGs"},
-                {"id": "HIPAA.Security-VPCNoUnrestrictedRouteToIGW", "reason": "Required for public ALB"},
-                {"id": "HIPAA.Security-VPCSubnetAutoAssignPublicIpDisabled",
-                 "reason": "ALB is the only public-facing resource"}
-            ],
-            apply_to_children=True
-        )
-        sg = stack.node.find_child(f"{name}-FrontendECSSecurityGroup")
-    else:
-        sg = stack.node.find_child(f"{name}-EndpointSG")
+    # Apply common VPC suppressions to the whole stack
     NagSuppressions.add_resource_suppressions(
-        sg,
+        stack,
         [
             {
-                "id": "AwsSolutions-EC23",
-                "reason": "CDK Nag cannot evaluate VPC CIDR block when used in ingress rule. Ingress is correctly scoped to internal HTTPS only."
+                "id": "HIPAA.Security-VPCDefaultSecurityGroupClosed",
+                "reason": "Default SG is unused; all resources have explicit SGs"
             },
             {
-                "id": "HIPAA.Security-EC2RestrictedCommonPorts",
-                "reason": "443 ingress is internal-only; CDK Nag cannot evaluate CIDR scope."
+                "id": "HIPAA.Security-VPCNoUnrestrictedRouteToIGW",
+                "reason": "Required for public ALB"
             },
             {
-                "id": "HIPAA.Security-EC2RestrictedSSH",
-                "reason": "Rule only allows port 443. SSH is not open."
-            },
-        ]
+                "id": "HIPAA.Security-VPCSubnetAutoAssignPublicIpDisabled",
+                "reason": "Public IPs needed for internet-facing ALB; no EC2 exposure"
+            }
+        ],
+        apply_to_children=True
     )
+
+    # Choose security group based on stack type
+    if stack.__class__.__name__ != "GalvBackend":
+        sg_id = f"{name}-FrontendECSSecurityGroup"
+    else:
+        sg_id = f"{name}-EndpointSG"
+
+    try:
+        sg = stack.node.find_child(sg_id)
+        if sg:
+            NagSuppressions.add_resource_suppressions(
+                sg,
+                [
+                    {
+                        "id": "AwsSolutions-EC23",
+                        "reason": "Ingress is restricted to internal HTTPS; CIDR scope not evaluable by CDK Nag"
+                    },
+                    {
+                        "id": "HIPAA.Security-EC2RestrictedCommonPorts",
+                        "reason": "Port 443 is allowed only internally"
+                    },
+                    {
+                        "id": "HIPAA.Security-EC2RestrictedSSH",
+                        "reason": "SSH is not open; rule only allows HTTPS"
+                    },
+                ]
+            )
+    except Exception as e:
+        print(f"[SKIP] Security group {sg_id} not found, skipping SG suppressions.")
+
 
 
 def _suppress_backend_bucket(stack: Stack, name: str):


### PR DESCRIPTION
These are expensive, the live site continued to work with me manually deleting them (as expected), the reason this is expected is because everything except the database is being granted explicit public internet gateway access so can access the aws services over the internet.

However, it is possible that this will break deployment depending on what order things are designed to happen, if for example public ip is not assigned before the containers are fetched.


I expect this to work though.